### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ VWO.prototype.initialize = function() {
  * https://vwo.com/knowledge/vwo-revenue-tracking-goal
  */
 
-VWO.prototype.completedOrder = function(track) {
+VWO.prototype.orderCompleted = function(track) {
   var total = track.total() || track.revenue() || 0;
   enqueue(function() {
     window._vis_opt_revenue_conversion(total);

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-visual-website-optimizer#readme",
   "dependencies": {
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "next-tick": "^0.2.2"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -139,14 +139,14 @@ describe('Visual Website Optimizer', function() {
       analytics.page();
     });
 
-    describe('#completedOrder', function() {
+    describe('#orderCompleted', function() {
       beforeEach(function() {
         analytics.stub(window._vis_opt_queue, 'push');
         analytics.stub(window, '_vis_opt_revenue_conversion');
       });
 
-      it('should track completed order', function() {
-        analytics.track('completed order', {
+      it('should track order completed', function() {
+        analytics.track('order completed', {
           orderId: '12074d48',
           tax: 16,
           total: 166,


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
