### PR TITLE
Add Experiment Viewed Non-Interactive option for Google Analytics

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,8 @@ var VWO = module.exports = integration('Visual Website Optimizer')
   .option('libraryTolerance', 2500)
   .option('useExistingJQuery', false)
   .option('replay', true)
-  .option('listen', false);
+  .option('listen', false)
+  .option('experimentNonInteraction', false);
 
 /**
  * The context for this integration.
@@ -111,12 +112,16 @@ VWO.prototype.roots = function() {
 
   rootExperiments(function(err, data) {
     each(data, function(experimentId, variationName) {
+      var props = {
+        experimentId: experimentId,
+        variationName: variationName
+      }
+      
+      if (this.options.experimentNonInteraction) props.nonInteraction = 1;
+      
       analytics.track(
         'Experiment Viewed',
-        {
-          experimentId: experimentId,
-          variationName: variationName
-        },
+        props,
         { context: { integration: integrationContext } }
       );
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,9 +116,9 @@ VWO.prototype.roots = function() {
         experimentId: experimentId,
         variationName: variationName
       };
-      
-      if (this.options.experimentNonInteraction) props.nonInteraction = 1;
-      
+
+      if (self.options.experimentNonInteraction) props.nonInteraction = 1;
+
       analytics.track(
         'Experiment Viewed',
         props,

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,7 @@ VWO.prototype.replay = function() {
 
 VWO.prototype.roots = function() {
   var analytics = this.analytics;
+  var self = this;
 
   rootExperiments(function(err, data) {
     each(data, function(experimentId, variationName) {
@@ -118,7 +119,7 @@ VWO.prototype.roots = function() {
       };
 
       if (self.options.experimentNonInteraction) props.nonInteraction = 1;
-
+      
       analytics.track(
         'Experiment Viewed',
         props,

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,7 @@ VWO.prototype.roots = function() {
       var props = {
         experimentId: experimentId,
         variationName: variationName
-      }
+      };
       
       if (this.options.experimentNonInteraction) props.nonInteraction = 1;
       

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -127,6 +127,7 @@ describe('Visual Website Optimizer', function() {
           variationName: 'Variation' },
           { context: { integration: { name: 'visual-website-optimizer', version: '1.0.0' } }
         });
+
         done();
       });
     });
@@ -148,7 +149,7 @@ describe('Visual Website Optimizer', function() {
         done();
       });
     });
-    
+
     it('should send experiment views as non-interactive if enabled', function(done) {
       vwo.options.listen = true;
       vwo.options.experimentNonInteractive = true;
@@ -160,7 +161,7 @@ describe('Visual Website Optimizer', function() {
 
         analytics.called(analytics.track, 'Experiment Viewed', {
           experimentId: '1',
-          variationName: 'Variation', 
+          variationName: 'Variation',
           nonInteractive: 1 },
           { context: { integration: { name: 'visual-website-optimizer', version: '1.0.0' } }
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -152,7 +152,7 @@ describe('Visual Website Optimizer', function() {
 
     it('should send experiment views as non-interactive if enabled', function(done) {
       vwo.options.listen = true;
-      vwo.options.experimentNonInteractive = true;
+      vwo.options.experimentNonInteraction = true;
       analytics.initialize();
       analytics.page();
 
@@ -162,7 +162,7 @@ describe('Visual Website Optimizer', function() {
         analytics.called(analytics.track, 'Experiment Viewed', {
           experimentId: '1',
           variationName: 'Variation',
-          nonInteractive: 1 },
+          nonInteraction: 1 },
           { context: { integration: { name: 'visual-website-optimizer', version: '1.0.0' } }
         });
         done();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,6 +148,25 @@ describe('Visual Website Optimizer', function() {
         done();
       });
     });
+    
+    it('should send experiment views as non-interactive if enabled', function(done) {
+      vwo.options.listen = true;
+      vwo.options.experimentNonInteractive = true;
+      analytics.initialize();
+      analytics.page();
+
+      tick(function() {
+        window._vis_opt_queue[1]();
+
+        analytics.called(analytics.track, 'Experiment Viewed', {
+          experimentId: '1',
+          variationName: 'Variation', 
+          nonInteractive: 1 },
+          { context: { integration: { name: 'visual-website-optimizer', version: '1.0.0' } }
+        });
+        done();
+      });
+    });
   });
 
   describe('after loading', function() {


### PR DESCRIPTION
This destination has been missing an option to make Experiment Viewed events non-interactive for when we repeat it to Google Analytics users, resulting in low bounce rates. This will give our Google Analytics + VWO users the ability to make their events non-interactive to preserve sessions.